### PR TITLE
feat: Add basic index.html with dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Arcade</title>
+  <style>
+    body {
+      background-color: #121212;
+      color: #e0e0e0;
+      font-family: sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: space-between;
+      margin: 0;
+    }
+    h1 {
+      text-align: center;
+    }
+    footer {
+      text-align: center;
+      padding: 20px;
+      font-size: 0.8em;
+      color: #aaa;
+      width: 100%;
+    }
+  </style>
+</head>
+<body>
+  <h1>arcade</h1>
+  <footer>
+    copyright 2025 Ron B. Yeh | <a href="https://github.com/ronyeh/arcade">View on GitHub</a>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a simple `index.html` file at the root of the repository.

The page displays the word "arcade" as a main heading. It features a dark theme with a dark background and light text. The footer includes "copyright 2025 Ron B. Yeh" and a link to the GitHub repository (https://github.com/ronyeh/arcade).