### PR TITLE
fix: Make footer link visible on dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,9 @@
       color: #aaa;
       width: 100%;
     }
+  footer a {
+    color: lightblue;
+  }
   </style>
 </head>
 <body>


### PR DESCRIPTION
The previous commit added a link to the GitHub repository in the footer, but the link color was not adjusted for the dark theme, making it difficult to see.

This commit updates the CSS to set the color of the anchor tag (`a`) within the footer to `lightblue`, ensuring it is clearly visible against the dark background and distinct from the surrounding text.